### PR TITLE
fix 1.10.2 :snowflake:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,11 @@ requirements:
 test:
   imports:
     - avro
+    - avro.io
+    - avro.datafile
+    - avro.protocol
+    - avro.schema
+    - avro.ipc
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 3b63f24e6b04368c3e4a6f923f484be0230d821aad65ac36108edbff29e9aaab
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -v
   skip: True  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - python
     - setuptools
     - wheel
-    - avro
     - isort
     - pip
     - pycodestyle


### PR DESCRIPTION
avro-python3 1.10.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3811]
- [Upstream repository](https://github.com/AnacondaRecipes/avro-python3)

### Explanation of changes:

- fix the problem with host dependency `avro`, which happened to have sdist files not included in the produced package
    

[PKG-3811]: https://anaconda.atlassian.net/browse/PKG-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ